### PR TITLE
Update batch size and add timeout

### DIFF
--- a/backend/rag_3/config.yaml
+++ b/backend/rag_3/config.yaml
@@ -13,6 +13,7 @@ text_llm:
   deployment_name: "gpt4-turbo"
   temperature: 0.0
   max_tokens: 1024
+  timeout: 120
 
 vision_llm:
   _target_: langchain_openai.AzureChatOpenAI
@@ -22,6 +23,7 @@ vision_llm:
   deployment_name: "gpt4-vision"
   temperature: 0.0
   max_tokens: 1024
+  timeout: 120
 
 embedding:
   _target_: langchain_openai.AzureOpenAIEmbeddings

--- a/backend/rag_components/summarization.py
+++ b/backend/rag_components/summarization.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 
 
 @retry(
-    retry=retry_if_exception_type((openai.RateLimitError, openai.BadRequestError)),
+    retry=retry_if_exception_type(
+        (openai.RateLimitError, openai.BadRequestError, openai.APITimeoutError)
+    ),
     wait=wait_exponential(multiplier=60, max=180),
     stop=stop_after_delay(600),
     before=before_log(logger, logging.INFO),


### PR DESCRIPTION
This pull request updates the batch size for generating text and image summaries and adds a timeout of 120 seconds for both processes. The batch size is reduced from 50 to 10 for better performance. The `generate_text_summaries` and `generate_image_summaries` functions now use the `abatch_with_retry` function for processing batches with retries on failure.