### PR TITLE
Add image padding configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ For all options, we can choose to treat tables as text or images.
 - `ingest.table_min_size` : Minimum relative size for tables to be considered.
 - `ingest.export_extracted` : Whether to export extracted elements in local folder.
 
+Padding around extracted images can be adjusted by specifying two environment variables `"EXTRACT_IMAGE_BLOCK_CROP_HORIZONTAL_PAD"` and `"EXTRACT_IMAGE_BLOCK_CROP_VERTICAL_PAD"`.
+
 ### RAG Option 1
 
 Folder: [backend/rag_1](backend/rag_1)

--- a/template.env
+++ b/template.env
@@ -17,3 +17,7 @@ ADMIN_MODE=0
 
 BACKEND_URL="http://localhost:8000/"
 BACKEND_URL_RAG="http://localhost:8000/rag-3/"
+
+# See : https://unstructured-io.github.io/unstructured/core/partition.html#partition-pdf
+EXTRACT_IMAGE_BLOCK_CROP_HORIZONTAL_PAD=150
+EXTRACT_IMAGE_BLOCK_CROP_VERTICAL_PAD=150


### PR DESCRIPTION
This pull request adds the ability to adjust the padding around extracted images by specifying two environment variables: "EXTRACT_IMAGE_BLOCK_CROP_HORIZONTAL_PAD" and "EXTRACT_IMAGE_BLOCK_CROP_VERTICAL_PAD". This allows for more control over the appearance of the extracted images.