### PR TITLE
Fix handling of empty image list

### DIFF
--- a/backend/rag_components/retriever.py
+++ b/backend/rag_components/retriever.py
@@ -72,6 +72,8 @@ def add_documents_multivector(
         raise ValueError(
             "The length of vectorstore_content and metadata_list must be the same"
         )
+    if len(vectorstore_content) == 0:
+        return
 
     if not isinstance(retriever, MultiVectorRetriever):
         raise ValueError("retriever must be a MultiVectorRetriever")

--- a/backend/rag_components/unstructured.py
+++ b/backend/rag_components/unstructured.py
@@ -62,6 +62,12 @@ def select_images(
         if width < min_size[0] or height < min_size[1]:
             continue
 
+        if (
+            element.metadata.image_mime_type is None
+            or element.metadata.image_base64 is None
+        ):
+            continue
+
         image = Image(
             base64=element.metadata.image_base64,
             mime_type=element.metadata.image_mime_type,


### PR DESCRIPTION
This pull request fixes a bug in the code that handles empty image lists. Previously, an error would occur when trying to add documents to the vector store if the image list was empty. 